### PR TITLE
feat: mark ignored lines as covered instead of removing them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage.out
 go-ignore-cov
 .vscode
 lcov.info
+.idea

--- a/README.md
+++ b/README.md
@@ -99,7 +99,3 @@ The block in which you put the ignore instruction is completely ignored.
 ### ignoring a whole file
 
 You can also ignore a whole file using `//coverage:ignore file`. You can put the comment anywhere in the file, but usually the first line is best for readability.
-
-## Caveats
-
-When using `go tool cover -func=coverage.out` to see the functions coverage, it will display all the functions in the scanned packages. If you add ignore statement to some functions, they will display 0% coverage when running `go tool cover`, but the 0% won't be used to calculate the total, so if you grep on the total like in the example above, you can still get 100%.

--- a/example/dummy.go
+++ b/example/dummy.go
@@ -6,7 +6,6 @@ import (
 	"github.com/quantumcycle/go-ignore-cov/example/hello"
 )
 
-//this package should have 100% code coverage if we remove the ignored statements
 func MaybeSayHello() {
 	// coverage:ignore
 	if err, ok := hello.SayHello(); err != nil && ok {
@@ -15,4 +14,9 @@ func MaybeSayHello() {
 	}
 	// coverage:ignore
 	fmt.Println("OK")
+}
+
+func NotCoveredButIgnored() {
+	//coverage:ignore
+	fmt.Println("This function is not covered")
 }


### PR DESCRIPTION
Fixes #1 

- Changed behavior to set coverage count to 1 for ignored lines instead of removing them
- Added performance optimizations:
  - Pre-compiled regex at package level
  - Replaced string formatting with arithmetic operations for position comparison
  - Implemented parallel file scanning with worker pool
  - Added early exit with bytes.Contains check
  - Switched to more efficient filepath.WalkDir
- Updated CLI usage description to reflect new behavior
- Bumped version to 0.5.0