### PR TITLE
feat: cli option to ignore empty functions

### DIFF
--- a/example/dummy.go
+++ b/example/dummy.go
@@ -47,3 +47,7 @@ func NotCoveredButIgnored() {
 	//coverage:ignore
 	fmt.Println("This function is not covered")
 }
+
+func emptyFunction() {
+	//nothing to do, noop
+}


### PR DESCRIPTION
`go tool cover` will report functions with no statements as 0% covered. This option mark them as covered