### PR TITLE
fix: ignore coverage statement in strings

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,6 +116,16 @@ func getInstructionFromLine(line string) (instruction string, reason string, ok 
 	if !strings.HasSuffix(prefix, "//") {
 		return "", "", false
 	}
+	// Reject // embedded inside a string literal: a real comment's // is
+	// either at the start of the line or preceded by a space/tab.
+	// e.g. `regexp.MustCompile(`//coverage:ignore`)` has '`' before //,
+	// and `"//coverage:ignore"` has '"' before // — both are false positives.
+	if slashPos := len(prefix) - 2; slashPos > 0 {
+		ch := prefix[slashPos-1]
+		if ch != ' ' && ch != '\t' {
+			return "", "", false
+		}
+	}
 	tail := strings.TrimSpace(line[idx+len("coverage:ignore"):])
 	tokens := strings.Fields(tail)
 	instruction = InstructionBlock
@@ -392,6 +402,19 @@ type reasonViolation struct {
 	message  string
 }
 
+func filterIgnoreCoverages(ics []IgnoreCoverage, pm *PatternMatcher) []IgnoreCoverage {
+	if pm == nil {
+		return ics
+	}
+	var filtered []IgnoreCoverage
+	for _, ic := range ics {
+		if _, matches := pm.MatchesFile(ic.Filepath); !matches {
+			filtered = append(filtered, ic)
+		}
+	}
+	return filtered
+}
+
 func validateReasons(ignoreCoverages []IgnoreCoverage, validReasons map[string]bool, reasonNames []string, requireReason bool) []reasonViolation {
 	var violations []reasonViolation
 	for _, ic := range ignoreCoverages {
@@ -547,7 +570,7 @@ func main() {
 			}
 
 			if configLoaded {
-				violations := validateReasons(ignoreCoverages, validReasons, reasonNames, requireReason)
+				violations := validateReasons(filterIgnoreCoverages(ignoreCoverages, patternMatcher), validReasons, reasonNames, requireReason)
 				if len(violations) > 0 {
 					for _, v := range violations {
 						fmt.Fprintf(os.Stderr, "%s:%d: %s\n", v.filepath, v.line, v.message)

--- a/main_test.go
+++ b/main_test.go
@@ -24,6 +24,11 @@ func TestGetInstructionFromLine(t *testing.T) {
 		{"// some other comment", "", "", false},
 		{"", "", "", false},
 		{`s := "coverage:ignore"`, "", "", false},
+		// // embedded in a string literal must not be treated as a directive.
+		{"var re = regexp.MustCompile(`//coverage:ignore`)", "", "", false},
+		{`var re = regexp.MustCompile(` + "`" + `\S.*//coverage:ignore` + "`" + `)`, "", "", false},
+		{`msg := "//coverage:ignore must have reason"`, "", "", false},
+		{`msg := fmt.Sprintf("//coverage:ignore has unknown reason=%q", r)`, "", "", false},
 	}
 	for _, tt := range tests {
 		instruction, reason, ok := getInstructionFromLine(tt.line)
@@ -160,6 +165,35 @@ func TestValidateReasonsRequireReason(t *testing.T) {
 	}
 	if violations[0].line != 9 {
 		t.Errorf("expected violation at line 9, got %d", violations[0].line)
+	}
+}
+
+func TestFilterIgnoreCoveragesExcludesMatchedPaths(t *testing.T) {
+	pm := &PatternMatcher{
+		GlobPatterns: []string{"tools/**"},
+		Root:         "/repo",
+	}
+	ics := []IgnoreCoverage{
+		{Filepath: "/repo/tools/qualitygate/foo.go"},
+		{Filepath: "/repo/service/domain/bar.go"},
+	}
+	got := filterIgnoreCoverages(ics, pm)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 after filtering, got %d", len(got))
+	}
+	if got[0].Filepath != "/repo/service/domain/bar.go" {
+		t.Errorf("unexpected filepath: %s", got[0].Filepath)
+	}
+}
+
+func TestFilterIgnoreCoveragesNilMatcher(t *testing.T) {
+	ics := []IgnoreCoverage{
+		{Filepath: "/repo/tools/foo.go"},
+		{Filepath: "/repo/service/bar.go"},
+	}
+	got := filterIgnoreCoverages(ics, nil)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 (nil matcher keeps all), got %d", len(got))
 	}
 }
 


### PR DESCRIPTION
Ignore "coverage:ignore" statement that are not comments